### PR TITLE
render prop to return the redirect component

### DIFF
--- a/src/components/Courses.js
+++ b/src/components/Courses.js
@@ -16,7 +16,7 @@ const Courses = () => (
     </div>
     
     {/* Write routes here... */}
-    <Redirect to="/courses/html" />
+    <Route exact path="/courses" render={ () => <Redirect to="/courses/html" /> } />
     <Route path="/courses/html" component={HTML} />
     <Route path="/courses/css" component={Css} />
     <Route path="/courses/javascript" component={JavaScript}  />


### PR DESCRIPTION
React Router provides an <Redirect> component that instructs the router to redirect from one route to another.

- Render a redirect component that will navigate to the new location
( the Redirect component is like a regular React component )
- Create a route that matches the path /courses 
- Use the render prop to return the Redirect component
- To render this redirect when the path is exact /courses, we need to include the exact prop!!